### PR TITLE
Development to Main (security updates)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "chat.tools.terminal.autoApprove": {
-        "/^python3 -m pytest 03_application/tests/backend/test_analytics_environment_inference\\.py::test_insight_dashboard_filters_kpis_results_and_predictions -v 2>&1 \\| head -50$/": {
-            "approve": true,
-            "matchCommandLine": true
-        }
-    }
-}

--- a/03_application/backend/README.md
+++ b/03_application/backend/README.md
@@ -15,6 +15,13 @@ cp .env.example .env
 
 Generate a secure `SECRET_KEY` in `.env`.
 
+For production or staging:
+
+- Use a randomly generated `SECRET_KEY` of at least 32 characters.
+- Change `ADMIN_PASSWORD`; the local default is rejected outside development.
+- Set explicit `CORS_ORIGINS`; wildcard origins are rejected outside development.
+- Serve the API only behind HTTPS and keep database/Neo4j ports private.
+
 ## 2) Install dependencies
 
 ```bash

--- a/03_application/backend/app/api/analysis.py
+++ b/03_application/backend/app/api/analysis.py
@@ -305,7 +305,6 @@ def model_stats(
     return {
         'model': {
             'weights_file': Path(settings.model_weights_path).name,
-            'weights_path': settings.model_weights_path,
             'confidence_threshold': settings.model_confidence,
             'image_size': settings.model_image_size,
         },

--- a/03_application/backend/app/api/auth.py
+++ b/03_application/backend/app/api/auth.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.core.rate_limit import check_rate_limit
 from app.core.security import create_access_token, hash_password, verify_password
 from app.db.session import get_db
 from app.models import User
@@ -12,7 +13,8 @@ router = APIRouter(prefix='/api/auth', tags=['auth'])
 
 
 @router.post('/register', response_model=UserProfile)
-def register(payload: RegisterRequest, db: Session = Depends(get_db)):
+def register(payload: RegisterRequest, request: Request, db: Session = Depends(get_db)):
+    check_rate_limit(request, scope='register', identifier=payload.email)
     existing = db.query(User).filter(User.email == payload.email.lower()).first()
     if existing:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Email already in use')
@@ -37,7 +39,8 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)):
 
 
 @router.post('/login', response_model=TokenResponse)
-def login(payload: LoginRequest, db: Session = Depends(get_db)):
+def login(payload: LoginRequest, request: Request, db: Session = Depends(get_db)):
+    check_rate_limit(request, scope='login', identifier=payload.email)
     user = db.query(User).filter(User.email == payload.email.lower(), User.is_active.is_(True)).first()
     if user is None or not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid email or password')

--- a/03_application/backend/app/api/deps.py
+++ b/03_application/backend/app/api/deps.py
@@ -21,12 +21,17 @@ def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
         user_id = payload.get('sub')
-        if user_id is None:
+        token_type = payload.get('type')
+        if user_id is None or token_type != 'access':
             raise credentials_exception
+        try:
+            user_id_int = int(user_id)
+        except (TypeError, ValueError) as exc:
+            raise credentials_exception from exc
     except JWTError as exc:
         raise credentials_exception from exc
 
-    user = db.query(User).filter(User.id == int(user_id), User.is_active.is_(True)).first()
+    user = db.query(User).filter(User.id == user_id_int, User.is_active.is_(True)).first()
     if user is None:
         raise credentials_exception
     return user

--- a/03_application/backend/app/core/config.py
+++ b/03_application/backend/app/core/config.py
@@ -1,8 +1,11 @@
 from functools import lru_cache
 from typing import List
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_ADMIN_PASSWORD = 'Admin123!ChangeMe'
+PRODUCTION_ENVS = {'prod', 'production', 'staging'}
 
 
 class Settings(BaseSettings):
@@ -13,8 +16,8 @@ class Settings(BaseSettings):
     api_host: str = Field(default='0.0.0.0', alias='API_HOST')
     api_port: int = Field(default=8000, alias='API_PORT')
 
-    secret_key: str = Field(alias='SECRET_KEY')
-    access_token_expire_minutes: int = Field(default=120, alias='ACCESS_TOKEN_EXPIRE_MINUTES')
+    secret_key: str = Field(alias='SECRET_KEY', min_length=32)
+    access_token_expire_minutes: int = Field(default=120, ge=5, le=1440, alias='ACCESS_TOKEN_EXPIRE_MINUTES')
 
     postgres_url: str = Field(alias='POSTGRES_URL')
 
@@ -33,8 +36,22 @@ class Settings(BaseSettings):
     cors_origins_raw: str = Field(default='http://localhost:5173', alias='CORS_ORIGINS')
 
     admin_email: str = Field(default='admin@local.test', alias='ADMIN_EMAIL')
-    admin_password: str = Field(default='Admin123!ChangeMe', alias='ADMIN_PASSWORD')
+    admin_password: str = Field(default=DEFAULT_ADMIN_PASSWORD, min_length=12, alias='ADMIN_PASSWORD')
     admin_name: str = Field(default='Local Admin', alias='ADMIN_NAME')
+
+    @field_validator('app_env')
+    @classmethod
+    def normalize_app_env(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @model_validator(mode='after')
+    def validate_security_settings(self) -> 'Settings':
+        if self.app_env in PRODUCTION_ENVS:
+            if self.admin_password == DEFAULT_ADMIN_PASSWORD:
+                raise ValueError('ADMIN_PASSWORD must be changed outside local development')
+            if '*' in self.cors_origins:
+                raise ValueError('Wildcard CORS origins are not allowed outside local development')
+        return self
 
     @property
     def cors_origins(self) -> List[str]:

--- a/03_application/backend/app/core/rate_limit.py
+++ b/03_application/backend/app/core/rate_limit.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from time import monotonic
+from threading import Lock
+
+from fastapi import HTTPException, Request, status
+
+AUTH_RATE_LIMIT_ATTEMPTS = 8
+AUTH_RATE_LIMIT_WINDOW_SECONDS = 60
+
+_attempts: dict[str, deque[float]] = defaultdict(deque)
+_lock = Lock()
+
+
+def _client_host(request: Request | None) -> str:
+    if request is None or request.client is None:
+        return 'direct-call'
+    forwarded = request.headers.get('x-forwarded-for')
+    if forwarded:
+        return forwarded.split(',', 1)[0].strip()
+    return request.client.host
+
+
+def check_rate_limit(
+    request: Request | None,
+    *,
+    scope: str,
+    identifier: str,
+    limit: int = AUTH_RATE_LIMIT_ATTEMPTS,
+    window_seconds: int = AUTH_RATE_LIMIT_WINDOW_SECONDS,
+) -> None:
+    key = f'{scope}:{_client_host(request)}:{identifier.lower().strip()}'
+    now = monotonic()
+    with _lock:
+        window = _attempts[key]
+        while window and now - window[0] > window_seconds:
+            window.popleft()
+        if len(window) >= limit:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail='Too many attempts. Try again later.',
+                headers={'Retry-After': str(window_seconds)},
+            )
+        window.append(now)
+
+
+def clear_rate_limit_state() -> None:
+    with _lock:
+        _attempts.clear()

--- a/03_application/backend/app/core/security.py
+++ b/03_application/backend/app/core/security.py
@@ -21,6 +21,7 @@ def hash_password(password: str) -> str:
 def create_access_token(subject: str, role: str) -> str:
     settings = get_settings()
     expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
-    expire = datetime.now(timezone.utc) + expires_delta
-    payload: Dict[str, Any] = {'sub': subject, 'role': role, 'exp': expire}
+    issued_at = datetime.now(timezone.utc)
+    expire = issued_at + expires_delta
+    payload: Dict[str, Any] = {'sub': subject, 'role': role, 'type': 'access', 'iat': issued_at, 'exp': expire}
     return jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)

--- a/03_application/backend/app/core/security_headers.py
+++ b/03_application/backend/app/core/security_headers.py
@@ -1,0 +1,24 @@
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request, Response
+
+
+SECURITY_HEADERS = {
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+    'Cross-Origin-Resource-Policy': 'same-origin',
+}
+
+
+async def add_security_headers(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    response = await call_next(request)
+    for header, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(header, value)
+    if request.url.scheme == 'https':
+        response.headers.setdefault('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+    return response

--- a/03_application/backend/app/main.py
+++ b/03_application/backend/app/main.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.api import admin, analysis, analytics, auth, environment, fields, map
 from app.core.config import get_settings
 from app.core.security import hash_password
+from app.core.security_headers import add_security_headers
 from app.db.base import Base
 from app.db.session import engine
 from app.models import User
@@ -14,6 +15,7 @@ from app.services.graph_service import GraphService
 settings = get_settings()
 
 app = FastAPI(title=settings.app_name)
+app.middleware('http')(add_security_headers)
 
 app.add_middleware(
     CORSMiddleware,

--- a/03_application/backend/app/services/upload_service.py
+++ b/03_application/backend/app/services/upload_service.py
@@ -11,6 +11,7 @@ from fastapi import UploadFile
 ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'}
 MAX_UPLOAD_SIZE_MB = 20
 MAX_BATCH_UPLOAD_IMAGES = 50
+MAX_SIGNATURE_BYTES = 16
 _DATASET_FILENAME_MARKER = re.compile(r"(^|[^a-z])(train|training|valid|validation|test)([^a-z]|$)", re.IGNORECASE)
 IDENTIFIER_PATTERN = re.compile(r'^[A-Za-z0-9_-]+$')
 TRAP_CODE_PATTERN = re.compile(r'^[A-Za-z0-9 _-]+$')
@@ -74,6 +75,28 @@ def validate_upload_file(upload: UploadFile) -> None:
         allowed = ', '.join(sorted(ALLOWED_IMAGE_EXTENSIONS))
         raise ValueError(f'Unsupported image type "{suffix}". Allowed: {allowed}')
 
+    if not _signature_matches_extension(upload, suffix):
+        raise ValueError('Upload content does not match the declared image type')
+
+
+def _signature_matches_extension(upload: UploadFile, suffix: str) -> bool:
+    file_obj = upload.file
+    try:
+        position = file_obj.tell()
+    except (AttributeError, OSError):
+        position = None
+    header = file_obj.read(MAX_SIGNATURE_BYTES)
+    if position is not None:
+        file_obj.seek(position)
+
+    if suffix in {'.jpg', '.jpeg'}:
+        return header.startswith(b'\xff\xd8\xff')
+    if suffix == '.png':
+        return header.startswith(b'\x89PNG\r\n\x1a\n')
+    if suffix == '.webp':
+        return len(header) >= 12 and header.startswith(b'RIFF') and header[8:12] == b'WEBP'
+    return False
+
 
 def normalize_optional_text(value: str | None) -> str | None:
     if value is None:
@@ -115,14 +138,17 @@ def save_upload_file(
     trap_code: str | None = None,
     capture_date: date | None = None,
 ) -> Path:
+    root = upload_root.resolve()
     destination_dir = (
-        build_upload_storage_path(upload_root, field_id, trap_code, capture_date)
+        build_upload_storage_path(root, field_id, trap_code, capture_date)
         if field_id and trap_code and capture_date
-        else upload_root
+        else root
     )
     destination_dir.mkdir(parents=True, exist_ok=True)
     filename = f'{uuid4().hex}_{secure_filename(upload.filename or "upload.jpg")}'
-    destination = destination_dir / filename
+    destination = (destination_dir / filename).resolve()
+    if root != destination and root not in destination.parents:
+        raise ValueError('Resolved upload path escapes configured upload directory')
     max_bytes = MAX_UPLOAD_SIZE_MB * 1024 * 1024
     size_bytes = 0
     try:

--- a/03_application/frontend/src/api/__tests__/client.test.ts
+++ b/03_application/frontend/src/api/__tests__/client.test.ts
@@ -18,7 +18,9 @@ describe('apiClient', () => {
     expect(String(url)).toContain('/health');
     const headers = new Headers(init?.headers);
     expect(headers.get('Authorization')).toBe('Bearer token-123');
+    expect(headers.get('Accept')).toBe('application/json');
     expect(headers.get('Content-Type')).toBe('application/json');
+    expect(init?.referrerPolicy).toBe('same-origin');
   });
 
   it('sends JSON body for POST/PATCH', async () => {
@@ -63,12 +65,25 @@ describe('apiClient', () => {
     const [, init] = fetchMock.mock.calls[0];
     const headers = new Headers(init?.headers);
     expect(headers.get('Authorization')).toBe('Bearer token-csv');
+    expect(headers.get('Accept')).toBe('text/csv, text/plain');
     expect(headers.get('Content-Type')).toBeNull();
   });
 
   it('throws api message for non-ok response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('bad request', { status: 400 }));
     await expect(apiClient.get('/bad')).rejects.toThrow('bad request');
+  });
+
+  it('uses json detail errors and hides raw server errors', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ detail: 'Invalid credentials' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response('stack trace', { status: 500 }));
+
+    await expect(apiClient.get('/auth')).rejects.toThrow('Invalid credentials');
+    await expect(apiClient.get('/boom')).rejects.toThrow('Server error. Try again later.');
   });
 
   it('throws reachability message on fetch error', async () => {

--- a/03_application/frontend/src/api/client.ts
+++ b/03_application/frontend/src/api/client.ts
@@ -1,7 +1,25 @@
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8000';
 
+async function apiErrorMessage(response: Response): Promise<string> {
+  if (response.status >= 500) {
+    return 'Server error. Try again later.';
+  }
+  const contentType = response.headers.get('Content-Type') ?? '';
+  const text = await response.text();
+  if (contentType.includes('application/json')) {
+    try {
+      const payload = JSON.parse(text) as { detail?: unknown };
+      if (typeof payload.detail === 'string') return payload.detail;
+    } catch {
+      return text || 'Request failed';
+    }
+  }
+  return text || 'Request failed';
+}
+
 async function request<T>(path: string, init: RequestInit = {}, token?: string): Promise<T> {
   const headers = new Headers(init.headers || {});
+  headers.set('Accept', 'application/json');
   if (!(init.body instanceof FormData)) {
     headers.set('Content-Type', 'application/json');
   }
@@ -14,14 +32,14 @@ async function request<T>(path: string, init: RequestInit = {}, token?: string):
     response = await fetch(`${API_BASE}${path}`, {
       ...init,
       headers,
+      referrerPolicy: 'same-origin',
     });
   } catch {
     throw new Error(`Cannot reach API at ${API_BASE}. Ensure backend is running on port 8000.`);
   }
 
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || 'Request failed');
+    throw new Error(await apiErrorMessage(response));
   }
 
   return response.json() as Promise<T>;
@@ -29,6 +47,7 @@ async function request<T>(path: string, init: RequestInit = {}, token?: string):
 
 async function requestText(path: string, init: RequestInit = {}, token?: string): Promise<string> {
   const headers = new Headers(init.headers || {});
+  headers.set('Accept', 'text/csv, text/plain');
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
   }
@@ -38,14 +57,14 @@ async function requestText(path: string, init: RequestInit = {}, token?: string)
     response = await fetch(`${API_BASE}${path}`, {
       ...init,
       headers,
+      referrerPolicy: 'same-origin',
     });
   } catch {
     throw new Error(`Cannot reach API at ${API_BASE}. Ensure backend is running on port 8000.`);
   }
 
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || 'Request failed');
+    throw new Error(await apiErrorMessage(response));
   }
 
   return response.text();

--- a/03_application/frontend/src/types/api.ts
+++ b/03_application/frontend/src/types/api.ts
@@ -120,7 +120,6 @@ export type AnalyticsOverview = {
 export type ModelStats = {
   model: {
     weights_file: string;
-    weights_path: string;
     confidence_threshold: number;
     image_size: number;
   };

--- a/03_application/tests/backend/test_analysis_helpers.py
+++ b/03_application/tests/backend/test_analysis_helpers.py
@@ -222,6 +222,8 @@ def test_model_stats_and_list_uploads(monkeypatch: pytest.MonkeyPatch, tmp_path:
 
     stats = analysis_api.model_stats(db=db, current_user=DummyUser(id=1))
     assert stats["evaluation"]["precision"] == 0.9
+    assert stats["model"]["weights_file"] == "swd_yolo_best.pt"
+    assert "weights_path" not in stats["model"]
     assert stats["production_observed"]["total_uploads"] == 3
 
     rows = analysis_api.list_my_uploads(db=db, current_user=DummyUser(id=1, role="admin"))

--- a/03_application/tests/backend/test_auth_and_admin_api.py
+++ b/03_application/tests/backend/test_auth_and_admin_api.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from app.api import admin as admin_api
 from app.api import auth as auth_api
 from app.api import deps as deps_api
+from app.core.rate_limit import clear_rate_limit_state
 
 
 @dataclass
@@ -68,6 +69,7 @@ class FakeDB:
 
 
 def test_register_success_and_duplicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_rate_limit_state()
     user_payload = auth_api.RegisterRequest(email="u@example.com", full_name="User", password="password123")
 
     class FakeGraph:
@@ -81,16 +83,17 @@ def test_register_success_and_duplicate(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(auth_api, "hash_password", lambda p: "hashed")
 
     db_ok = FakeDB([FakeQuery(first_value=None)])
-    profile = auth_api.register(user_payload, db_ok)
+    profile = auth_api.register(user_payload, request=None, db=db_ok)
     assert profile.email == "u@example.com"
 
     db_dup = FakeDB([FakeQuery(first_value=DummyUser(1, "u@example.com", "U", "x"))])
     with pytest.raises(HTTPException) as exc:
-        auth_api.register(user_payload, db_dup)
+        auth_api.register(user_payload, request=None, db=db_dup)
     assert exc.value.status_code == 400
 
 
 def test_login_and_me(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_rate_limit_state()
     payload = auth_api.LoginRequest(email="u@example.com", password="password123")
     user = DummyUser(7, "u@example.com", "U", "hashed", role="admin")
 
@@ -98,16 +101,32 @@ def test_login_and_me(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(auth_api, "verify_password", lambda p, h: True)
     monkeypatch.setattr(auth_api, "create_access_token", lambda subject, role: f"token-{subject}-{role}")
 
-    token = auth_api.login(payload, db_ok)
+    token = auth_api.login(payload, request=None, db=db_ok)
     assert token.access_token == "token-7-admin"
 
     db_bad = FakeDB([FakeQuery(first_value=user)])
     monkeypatch.setattr(auth_api, "verify_password", lambda p, h: False)
     with pytest.raises(HTTPException) as exc:
-        auth_api.login(payload, db_bad)
+        auth_api.login(payload, request=None, db=db_bad)
     assert exc.value.status_code == 401
 
     assert auth_api.me(user).email == "u@example.com"
+
+
+def test_auth_rate_limit_rejects_repeated_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_rate_limit_state()
+    payload = auth_api.LoginRequest(email="limit@example.com", password="password123")
+    monkeypatch.setattr(auth_api, "verify_password", lambda p, h: False)
+    db = FakeDB([FakeQuery(first_value=DummyUser(7, "limit@example.com", "U", "hashed"))] * 8)
+    for _ in range(8):
+        with pytest.raises(HTTPException) as exc:
+            auth_api.login(payload, request=None, db=db)
+        assert exc.value.status_code == 401
+
+    with pytest.raises(HTTPException) as exc2:
+        auth_api.login(payload, request=None, db=FakeDB([FakeQuery(first_value=None)]))
+    assert exc2.value.status_code == 429
+    clear_rate_limit_state()
 
 
 def test_get_current_user_and_require_admin(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/03_application/tests/backend/test_auth_and_admin_api.py
+++ b/03_application/tests/backend/test_auth_and_admin_api.py
@@ -115,7 +115,7 @@ def test_get_current_user_and_require_admin(monkeypatch: pytest.MonkeyPatch) -> 
     db_ok = FakeDB([FakeQuery(first_value=user)])
 
     monkeypatch.setattr(deps_api, "get_settings", lambda: SimpleNamespace(secret_key="secret"))
-    monkeypatch.setattr(deps_api.jwt, "decode", lambda token, key, algorithms: {"sub": "9"})
+    monkeypatch.setattr(deps_api.jwt, "decode", lambda token, key, algorithms: {"sub": "9", "type": "access"})
 
     current = deps_api.get_current_user(db=db_ok, token="tok")
     assert current.id == 9
@@ -129,6 +129,16 @@ def test_get_current_user_and_require_admin(monkeypatch: pytest.MonkeyPatch) -> 
     with pytest.raises(HTTPException) as exc2:
         deps_api.get_current_user(db=db_none, token="tok")
     assert exc2.value.status_code == 401
+
+    monkeypatch.setattr(deps_api.jwt, "decode", lambda token, key, algorithms: {"sub": "not-an-int", "type": "access"})
+    with pytest.raises(HTTPException) as exc3:
+        deps_api.get_current_user(db=FakeDB([]), token="tok")
+    assert exc3.value.status_code == 401
+
+    monkeypatch.setattr(deps_api.jwt, "decode", lambda token, key, algorithms: {"sub": "9", "type": "refresh"})
+    with pytest.raises(HTTPException) as exc4:
+        deps_api.get_current_user(db=FakeDB([]), token="tok")
+    assert exc4.value.status_code == 401
 
 
 def test_admin_overview() -> None:

--- a/03_application/tests/backend/test_ingestion_pipeline_workflow.py
+++ b/03_application/tests/backend/test_ingestion_pipeline_workflow.py
@@ -46,7 +46,13 @@ def ingestion_user_and_field(db_session: Session) -> tuple[User, FieldMap]:
     return user, field
 
 
-def _upload(filename: str, content: bytes = b"fake-image-bytes") -> UploadFile:
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"fake-image-bytes"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-image-bytes"
+
+
+def _upload(filename: str, content: bytes | None = None) -> UploadFile:
+    if content is None:
+        content = PNG_BYTES if filename.lower().endswith(".png") else JPEG_BYTES
     return UploadFile(filename=filename, file=BytesIO(content))
 
 

--- a/03_application/tests/backend/test_security.py
+++ b/03_application/tests/backend/test_security.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
 pytest.importorskip("jose")
@@ -7,9 +10,11 @@ pytest.importorskip("passlib")
 
 from jose import jwt
 from passlib.exc import MissingBackendError
+from fastapi import Response
 
 from app.core import config as cfg
 from app.core.security import ALGORITHM, create_access_token, hash_password, verify_password
+from app.core.security_headers import add_security_headers
 
 
 def _seed_env(monkeypatch) -> None:  # noqa: ANN001
@@ -42,3 +47,16 @@ def test_create_access_token_contains_expected_claims(monkeypatch) -> None:  # n
     assert payload["type"] == "access"
     assert "iat" in payload
     assert "exp" in payload
+
+
+def test_security_headers_are_added_to_responses() -> None:
+    async def call_next(request):  # noqa: ANN001
+        _ = request
+        return Response()
+
+    request = SimpleNamespace(url=SimpleNamespace(scheme="http"))
+    response = asyncio.run(add_security_headers(request, call_next))
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=()"

--- a/03_application/tests/backend/test_security.py
+++ b/03_application/tests/backend/test_security.py
@@ -13,7 +13,7 @@ from app.core.security import ALGORITHM, create_access_token, hash_password, ver
 
 
 def _seed_env(monkeypatch) -> None:  # noqa: ANN001
-    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-local-tests-32")
     monkeypatch.setenv("POSTGRES_URL", "sqlite:///./test.db")
     monkeypatch.setenv("NEO4J_URI", "bolt://localhost:7687")
     monkeypatch.setenv("NEO4J_USER", "neo4j")
@@ -36,7 +36,9 @@ def test_hash_and_verify_password(monkeypatch) -> None:  # noqa: ANN001
 def test_create_access_token_contains_expected_claims(monkeypatch) -> None:  # noqa: ANN001
     _seed_env(monkeypatch)
     token = create_access_token(subject="user@example.com", role="admin")
-    payload = jwt.decode(token, "test-secret", algorithms=[ALGORITHM])
+    payload = jwt.decode(token, "test-secret-key-for-local-tests-32", algorithms=[ALGORITHM])
     assert payload["sub"] == "user@example.com"
     assert payload["role"] == "admin"
+    assert payload["type"] == "access"
+    assert "iat" in payload
     assert "exp" in payload

--- a/03_application/tests/backend/test_upload_service.py
+++ b/03_application/tests/backend/test_upload_service.py
@@ -20,6 +20,10 @@ from app.services.upload_service import (
     validate_upload_file,
 )
 
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"jpeg-bytes"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"png-bytes"
+WEBP_BYTES = b"RIFF\x10\x00\x00\x00WEBP" + b"webp-bytes"
+
 
 def test_secure_filename_strips_unsafe_chars() -> None:
     assert secure_filename("..//bad*name?.jpg") == "badname.jpg"
@@ -62,10 +66,21 @@ def test_save_upload_file_uses_hierarchical_storage_context(tmp_path: Path) -> N
 
 def test_upload_file_validation_rejects_unsupported_and_dataset_names() -> None:
     with pytest.raises(ValueError, match="Unsupported image type"):
-        validate_upload_file(SimpleNamespace(filename="trap.gif"))
+        validate_upload_file(SimpleNamespace(filename="trap.gif", file=BytesIO(b"GIF89a")))
 
     with pytest.raises(ValueError, match="Training/validation/test dataset images"):
-        validate_upload_file(SimpleNamespace(filename="training-sample.jpg"))
+        validate_upload_file(SimpleNamespace(filename="training-sample.jpg", file=BytesIO(JPEG_BYTES)))
+
+
+def test_upload_file_validation_checks_image_signature() -> None:
+    validate_upload_file(SimpleNamespace(filename="trap.jpg", file=BytesIO(JPEG_BYTES)))
+    validate_upload_file(SimpleNamespace(filename="trap.png", file=BytesIO(PNG_BYTES)))
+    validate_upload_file(SimpleNamespace(filename="trap.webp", file=BytesIO(WEBP_BYTES)))
+
+    spoofed = BytesIO(b"not-an-image")
+    with pytest.raises(ValueError, match="content does not match"):
+        validate_upload_file(SimpleNamespace(filename="trap.jpg", file=spoofed))
+    assert spoofed.tell() == 0
 
 
 def test_upload_metadata_normalization_and_format_validation() -> None:

--- a/03_application/tests/conftest.py
+++ b/03_application/tests/conftest.py
@@ -15,7 +15,7 @@ for path in (BACKEND, REPO_ROOT):
         sys.path.insert(0, str(path))
 
 # Defaults needed for importing backend settings in tests.
-os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-local-tests-32")
 os.environ.setdefault("POSTGRES_URL", "sqlite:///./test.db")
 os.environ.setdefault("NEO4J_URI", "bolt://localhost:7687")
 os.environ.setdefault("NEO4J_USER", "neo4j")

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,17 @@ Security fixes are prioritized for the current `main` branch.
 - Never commit raw user/sensor datasets under `04_modeling_experimental/data/raw`.
 - Rotate credentials immediately if exposure is suspected.
 - If secrets are committed, rewrite history and force push after remediation.
+
+## MVP Application Hardening
+
+The MVP API includes these baseline protections:
+
+- Passwords are stored with bcrypt hashes, never in plaintext.
+- API tokens are signed JWT access tokens with `exp`, `iat`, and token type claims.
+- Production-like environments must use a strong `SECRET_KEY`, non-default admin password, and explicit CORS origins.
+- Login and registration endpoints use basic in-memory throttling to reduce brute-force attempts.
+- API responses include browser security headers for MIME sniffing, clickjacking, referrer, permissions, and same-origin resource policy.
+- Uploads are constrained by extension, file size, batch size, image magic bytes, and upload-root path containment.
+- User-facing API errors hide raw server-side 5xx response bodies.
+
+Deployment still needs HTTPS termination, secret rotation, database/network firewalling, dependency vulnerability monitoring, backups, and environment-specific logging review. No application can be guaranteed impossible to hack; treat this policy as the current baseline and keep testing it as the deployment changes.


### PR DESCRIPTION
## Summary

This PR hardens the MVP application security baseline across authentication, configuration, API responses, upload validation, frontend error handling, and security documentation.

This does not claim the app is impossible to hack. It closes practical MVP-level risks and documents the remaining deployment responsibilities.

## Security Changes

- Enforces stronger auth configuration:
  - `SECRET_KEY` must be at least 32 characters.
  - Access token expiry is bounded.
  - Production/staging reject the default admin password.
  - Production/staging reject wildcard CORS origins.
- Adds stronger JWT claims:
  - Access tokens now include `type`, `iat`, and `exp`.
  - Auth dependency rejects invalid token type and non-integer user subjects.
- Adds API security headers:
  - `X-Content-Type-Options`
  - `X-Frame-Options`
  - `Referrer-Policy`
  - `Permissions-Policy`
  - `Cross-Origin-Resource-Policy`
  - HSTS when served over HTTPS.
- Adds basic auth throttling:
  - Login and registration attempts are rate limited per client/identifier.
- Hardens image uploads:
  - Validates JPG/PNG/WEBP magic bytes, not only file extensions.
  - Preserves existing extension, size, batch size, and dataset-name checks.
  - Ensures resolved upload paths stay inside the configured upload root.
- Reduces information disclosure:
  - Removes full model weights path from `/api/analysis/model-stats`.
  - Frontend hides raw 5xx server response bodies from users.
- Updates security documentation:
  - Documents current MVP security protections.
  - Calls out deployment responsibilities such as HTTPS, secret rotation, firewalling, dependency monitoring, backups, and logging review.

## Validation

- Backend focused tests:
  - `.venv/bin/python -m pytest -q 03_application/tests/backend/test_security.py 03_application/tests/backend/test_auth_and_admin_api.py 03_application/tests/backend/test_upload_service.py 03_application/tests/backend/test_ingestion_pipeline_workflow.py 03_application/tests/backend/test_analysis_helpers.py`
  - Result: `32 passed`
- Frontend focused tests:
  - `npm test -- --run src/api/__tests__/client.test.ts src/pages/__tests__/DashboardPage.test.tsx`
  - Result: `16 passed`
- Frontend build:
  - `npm run build`
  - Result: passed
