### PR TITLE
Development into Main

### DIFF
--- a/03_application/backend/app/api/access.py
+++ b/03_application/backend/app/api/access.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models import FieldMap, User
+
+
+def require_field_access(db: Session, field_id: str, current_user: User) -> FieldMap:
+    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
+    if field is None:
+        raise HTTPException(status_code=404, detail='Field not found')
+    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
+        raise HTTPException(status_code=403, detail='Forbidden')
+    return field

--- a/03_application/backend/app/api/analysis.py
+++ b/03_application/backend/app/api/analysis.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_, extract, func
 from sqlalchemy.orm import Session
 import requests
 
+from app.api.access import require_field_access
 from app.api.deps import get_current_user
 from app.core.config import get_settings
 from app.db.session import get_db
@@ -81,11 +82,7 @@ def upload_range(
         trap = db.query(TrapPoint).filter(TrapPoint.id == trap_id).first()
         if trap is None:
             raise HTTPException(status_code=404, detail='Trap not found')
-        field = db.query(FieldMap).filter(FieldMap.id == trap.field_id).first()
-        if field is None:
-            raise HTTPException(status_code=404, detail='Field not found')
-        if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-            raise HTTPException(status_code=403, detail='Forbidden')
+        field = require_field_access(db, trap.field_id, current_user)
         if field_id and field_id != field.id:
             raise HTTPException(status_code=400, detail='field_id does not match selected trap')
         resolved_field_id = field.id
@@ -95,11 +92,7 @@ def upload_range(
     else:
         if not field_id:
             raise HTTPException(status_code=400, detail='field_id is required when trap_id is not provided')
-        field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-        if field is None:
-            raise HTTPException(status_code=404, detail='Field not found')
-        if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-            raise HTTPException(status_code=403, detail='Forbidden')
+        field = require_field_access(db, field_id, current_user)
         resolved_field_id = field.id
         resolved_trap_code = trap_code or 'UNSPECIFIED'
 
@@ -353,11 +346,7 @@ def exploratory_chat(
 
     selected_field: FieldMap | None = None
     if requested_field_id:
-        selected_field = db.query(FieldMap).filter(FieldMap.id == str(requested_field_id)).first()
-        if selected_field is None:
-            raise HTTPException(status_code=404, detail='Field not found')
-        if current_user.role != 'admin' and selected_field.owner_user_id != current_user.id:
-            raise HTTPException(status_code=403, detail='Forbidden')
+        selected_field = require_field_access(db, str(requested_field_id), current_user)
 
     base_upload_query = apply_production_upload_filter(db.query(TrapUpload))
     if current_user.role != 'admin':

--- a/03_application/backend/app/api/analytics.py
+++ b/03_application/backend/app/api/analytics.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import extract, func
 from sqlalchemy.orm import Session
 
+from app.api.access import require_field_access
 from app.api.deps import get_current_user
 from app.core.config import get_settings
 from app.db.session import get_db
@@ -53,11 +54,7 @@ def _apply_insight_filters(
 def _validate_field_access(db: Session, field_id: str | None, current_user: User) -> None:
     if field_id is None:
         return
-    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-    if field is None:
-        raise HTTPException(status_code=404, detail='Field not found')
-    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail='Forbidden')
+    require_field_access(db, field_id, current_user)
 
 
 def _insight_payload(
@@ -309,11 +306,7 @@ def analytics_overview(
     if current_user.role != 'admin':
         years_query = years_query.filter(FieldMap.owner_user_id == current_user.id)
     if field_id is not None:
-        field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-        if field is None:
-            raise HTTPException(status_code=404, detail='Field not found')
-        if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-            raise HTTPException(status_code=403, detail='Forbidden')
+        require_field_access(db, field_id, current_user)
         years_query = years_query.filter(TrapUpload.field_id == field_id)
     available_year_rows = years_query.distinct().order_by(extract('year', TrapUpload.capture_date)).all()
     available_years = [int(row[0]) for row in available_year_rows if row[0] is not None]

--- a/03_application/backend/app/api/environment.py
+++ b/03_application/backend/app/api/environment.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, extract, func
 from sqlalchemy.orm import Session
 
+from app.api.access import require_field_access
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models import EnvironmentalDaily, EnvironmentalSourceDaily, FieldMap, TrapUpload, User
@@ -16,12 +17,7 @@ router = APIRouter(prefix='/api/environment', tags=['environment'])
 
 
 def _get_field_or_403(db: Session, field_id: str, current_user: User) -> FieldMap:
-    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-    if field is None:
-        raise HTTPException(status_code=404, detail='Field not found')
-    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail='Forbidden')
-    return field
+    return require_field_access(db, field_id, current_user)
 
 
 @router.post('/fields/{field_id}/sync')

--- a/03_application/backend/app/api/map.py
+++ b/03_application/backend/app/api/map.py
@@ -26,7 +26,11 @@ router = APIRouter(prefix='/api/map', tags=['map'])
 
 
 @router.get('/search', response_model=list[SearchResult])
-def search_location(q: str = Query(..., min_length=2, max_length=120)) -> list[SearchResult]:
+def search_location(
+    q: str = Query(..., min_length=2, max_length=120),
+    current_user: User = Depends(get_current_user),
+) -> list[SearchResult]:
+    _ = current_user
     response = requests.get(
         'https://nominatim.openstreetmap.org/search',
         params={'q': q, 'format': 'jsonv2', 'limit': 8},

--- a/03_application/backend/app/api/map.py
+++ b/03_application/backend/app/api/map.py
@@ -7,6 +7,7 @@ import requests
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from app.api.access import require_field_access
 from app.api.deps import get_current_user
 from app.db.session import get_db
 from app.models import FieldMap, TrapPoint, TrapUpload, User
@@ -103,11 +104,7 @@ def get_field_map(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> FieldMapDetail:
-    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-    if field is None:
-        raise HTTPException(status_code=404, detail='Field not found')
-    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail='Forbidden')
+    field = require_field_access(db, field_id, current_user)
     return _to_field_detail(field, field.traps)
 
 
@@ -118,11 +115,7 @@ def add_trap_to_field(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> FieldMapDetail:
-    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-    if field is None:
-        raise HTTPException(status_code=404, detail='Field not found')
-    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail='Forbidden')
+    field = require_field_access(db, field_id, current_user)
 
     polygon = [(point['lat'], point['lng']) for point in json.loads(field.polygon_geojson)]
     if not point_in_polygon(body.lat, body.lng, polygon):
@@ -155,11 +148,7 @@ def update_trap(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> FieldMapDetail:
-    field = db.query(FieldMap).filter(FieldMap.id == field_id).first()
-    if field is None:
-        raise HTTPException(status_code=404, detail='Field not found')
-    if current_user.role != 'admin' and field.owner_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail='Forbidden')
+    field = require_field_access(db, field_id, current_user)
 
     trap = db.query(TrapPoint).filter(TrapPoint.id == trap_id, TrapPoint.field_id == field.id).first()
     if trap is None:

--- a/03_application/frontend/package-lock.json
+++ b/03_application/frontend/package-lock.json
@@ -2909,9 +2909,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3560,9 +3560,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/03_application/frontend/src/components/__tests__/FieldMapManager.test.tsx
+++ b/03_application/frontend/src/components/__tests__/FieldMapManager.test.tsx
@@ -120,6 +120,7 @@ describe('FieldMapManager', () => {
 
     fireEvent.change(screen.getByPlaceholderText('Search farm location'), { target: { value: 'fa' } });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(getMock).toHaveBeenCalledWith('/api/map/search?q=fa', 'token'));
     await waitFor(() => expect(screen.getByRole('button', { name: 'Test Farm' })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Test Farm' }));
     await waitFor(() => expect(setViewMock).toHaveBeenCalled());

--- a/03_application/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/03_application/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -44,6 +44,7 @@ describe('AuthProvider', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('u@example.com'));
+    expect(getMock).toHaveBeenCalledWith('/api/auth/me', 'abc');
 
     await act(async () => {
       screen.getByText('logout').click();
@@ -63,6 +64,8 @@ describe('AuthProvider', () => {
     );
 
     await waitFor(() => expect(localStorage.getItem('auth_token')).toBeNull());
+    expect(screen.getByTestId('token').textContent).toBe('none');
+    expect(screen.getByTestId('user').textContent).toBe('none');
   });
 
   it('login stores token and register chains login', async () => {
@@ -81,10 +84,19 @@ describe('AuthProvider', () => {
     await act(async () => {
       screen.getByText('login').click();
     });
+    expect(postMock).toHaveBeenCalledWith('/api/auth/login', {
+      email: 'u@example.com',
+      password: 'password123',
+    });
     expect(localStorage.getItem('auth_token')).toBe('token-login');
 
     await act(async () => {
       screen.getByText('register').click();
+    });
+    expect(postMock).toHaveBeenCalledWith('/api/auth/register', {
+      email: 'n@example.com',
+      full_name: 'New User',
+      password: 'password123',
     });
     expect(localStorage.getItem('auth_token')).toBe('token-register');
   });

--- a/03_application/frontend/src/styles/__tests__/globalCss.test.ts
+++ b/03_application/frontend/src/styles/__tests__/globalCss.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(resolve(__dirname, '../global.css'), 'utf-8');
+
+describe('responsive global css', () => {
+  it('keeps the desktop page constraint intact', () => {
+    expect(css).toContain('.page {\n  max-width: 1200px;');
+    expect(css).toContain('margin: 0 auto;');
+  });
+
+  it('defines tablet rules for single-column content and scrollable tables', () => {
+    expect(css).toContain('@media (max-width: 768px)');
+    expect(css).toContain('grid-template-columns: minmax(0, 1fr);');
+    expect(css).toContain('min-width: 720px;');
+  });
+
+  it('defines mobile rules for stacked controls and touch-sized actions', () => {
+    expect(css).toContain('@media (max-width: 640px)');
+    expect(css).toContain('flex-direction: column;');
+    expect(css).toContain('min-height: 44px;');
+    expect(css).toContain('height: 360px !important;');
+  });
+});

--- a/03_application/frontend/src/styles/global.css
+++ b/03_application/frontend/src/styles/global.css
@@ -11,6 +11,7 @@
 body {
   margin: 0;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .page {
@@ -32,6 +33,8 @@ body {
   padding: 16px;
   margin-bottom: 16px;
   box-shadow: 0 8px 18px rgba(16, 42, 67, 0.08);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .auth-card {
@@ -202,6 +205,7 @@ button {
 .table-wrap {
   overflow-x: auto;
   margin-top: 12px;
+  -webkit-overflow-scrolling: touch;
 }
 
 .data-table {
@@ -392,6 +396,98 @@ button {
   }
   .map-header-center {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    width: 100%;
+    padding: 16px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbar .map-toolbar {
+    width: 100%;
+  }
+
+  .grid-2 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .map-toolbar {
+    align-items: stretch;
+  }
+
+  .map-toolbar input,
+  .map-toolbar select,
+  .map-toolbar button {
+    flex: 1 1 220px;
+    min-width: 0;
+  }
+
+  .data-table {
+    min-width: 720px;
+  }
+
+  .line-chart {
+    height: 220px;
+  }
+
+  .insight-detail {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 12px;
+  }
+
+  .auth-page {
+    place-items: start center;
+    padding-top: 24px;
+  }
+
+  .card {
+    padding: 12px;
+    border-radius: 8px;
+  }
+
+  .map-toolbar {
+    flex-direction: column;
+  }
+
+  .map-toolbar input,
+  .map-toolbar select,
+  .map-toolbar button,
+  .form button,
+  .link-btn {
+    width: 100%;
+    min-height: 44px;
+  }
+
+  .segmented-fieldset {
+    display: grid;
+  }
+
+  .insight-kpis {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .map-wrap .leaflet-container {
+    height: 360px !important;
+  }
+
+  .line-chart {
+    height: 200px;
+  }
+
+  .chat-log {
+    max-height: 260px;
   }
 }
 

--- a/03_application/tests/backend/test_ingestion_pipeline_workflow.py
+++ b/03_application/tests/backend/test_ingestion_pipeline_workflow.py
@@ -194,6 +194,49 @@ def test_upload_range_persists_structured_exact_trap_metadata(
     assert graph_calls == [(field.id, upload.id, date(2026, 5, 1), 1)]
 
 
+def test_upload_range_rejects_other_workspace_field(
+    db_session: Session,
+) -> None:
+    owner = User(
+        id=111,
+        email="owner@example.test",
+        full_name="Owner",
+        password_hash="not-used",
+        role="user",
+        is_active=True,
+    )
+    other = User(
+        id=222,
+        email="other@example.test",
+        full_name="Other",
+        password_hash="not-used",
+        role="user",
+        is_active=True,
+    )
+    field = FieldMap(
+        id="field-owned",
+        owner_user_id=owner.id,
+        name="Owned Field",
+        polygon_geojson="{}",
+        area_m2=100.0,
+    )
+    db_session.add_all([owner, other, field])
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        analysis_api.upload_range(
+            start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 1),
+            field_id=field.id,
+            trap_id=None,
+            trap_code="R01-P01",
+            images=[_upload("blocked.jpg")],
+            db=db_session,
+            current_user=other,
+        )
+    assert exc.value.status_code == 403
+
+
 def test_get_upload_prediction_result_returns_image_metadata_and_detections(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/03_application/tests/backend/test_map_api_endpoints.py
+++ b/03_application/tests/backend/test_map_api_endpoints.py
@@ -74,7 +74,7 @@ def test_search_location_parses_response(monkeypatch: pytest.MonkeyPatch) -> Non
             return [{"display_name": "A", "lat": "52.1", "lon": "5.2"}]
 
     monkeypatch.setattr(map_api.requests, "get", lambda *args, **kwargs: Resp())
-    out = map_api.search_location("Amsterdam")
+    out = map_api.search_location("Amsterdam", current_user=DummyUser(id=1))
     assert out[0].display_name == "A"
     assert out[0].lat == 52.1
     assert out[0].lng == 5.2
@@ -171,4 +171,3 @@ def test_list_and_get_field_maps() -> None:
     db_get = FakeDB([FakeQuery(first_value=detail_field)])
     got = map_api.get_field_map("field-1", db=db_get, current_user=DummyUser(id=1, role="admin"))
     assert got.id == "field-1"
-

--- a/03_application/tests/backend/test_map_api_endpoints.py
+++ b/03_application/tests/backend/test_map_api_endpoints.py
@@ -171,3 +171,18 @@ def test_list_and_get_field_maps() -> None:
     db_get = FakeDB([FakeQuery(first_value=detail_field)])
     got = map_api.get_field_map("field-1", db=db_get, current_user=DummyUser(id=1, role="admin"))
     assert got.id == "field-1"
+
+
+def test_field_map_access_rejects_other_workspace() -> None:
+    detail_field = SimpleNamespace(
+        id="field-1",
+        name="F1",
+        area_m2=10.0,
+        owner_user_id=99,
+        polygon_geojson='[{"lat": 52.0, "lng": 5.0}, {"lat": 52.1, "lng": 5.1}]',
+        traps=[],
+    )
+    with pytest.raises(HTTPException) as exc:
+        map_api.get_field_map("field-1", db=FakeDB([FakeQuery(first_value=detail_field)]), current_user=DummyUser(id=1, role="user"))
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Forbidden"

--- a/docs/structured_flows/auth_access_control_flow.md
+++ b/docs/structured_flows/auth_access_control_flow.md
@@ -1,0 +1,101 @@
+# Authentication and Access Control Flow
+
+## Goal
+
+Ensure MVP users operate inside their own workspace and cannot access unrelated fields, traps, uploads, predictions, or monitoring results.
+
+## Authentication Method
+
+The backend uses email/password login and signed JWT bearer access tokens.
+
+Entry points:
+
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/auth/me`
+
+Tokens include:
+
+- `sub`: authenticated user id
+- `role`: user role
+- `type`: `access`
+- `iat`: issued-at timestamp
+- `exp`: expiry timestamp
+
+Invalid, expired, malformed, or wrong-type tokens return `401` with a generic credential message.
+
+## Protected Backend Areas
+
+These MVP workflows require an authenticated user:
+
+- Field and trap management
+- Map search used inside the protected field workflow
+- Image upload and ingestion
+- Upload/result retrieval
+- Analytics, insights, monitoring, and environmental views
+- Exploratory analysis/reporting
+- Admin overview
+
+## Workspace Ownership
+
+Regular users are scoped to records linked to their user id or fields they own.
+
+Data linkage:
+
+- `FieldMap.owner_user_id` links fields to a workspace owner.
+- `TrapPoint.field_id` links traps to a field/workspace.
+- `TrapUpload.user_id` links uploads to the submitting user.
+- `TrapUpload.field_id` and `trap_id` keep uploads traceable to field/trap context.
+- `Detection.upload_id` links predictions to the stored upload.
+
+Shared backend access logic uses `require_field_access` for field-scoped operations. Regular users must own the field. Admin users may inspect all workspaces.
+
+## Role Behavior
+
+Regular users can:
+
+- Create and list their own fields.
+- Add and rename traps in their own fields.
+- Upload images to their own field or trap.
+- Retrieve their own upload and prediction results.
+- View analytics for their own workspace.
+
+Admin users can:
+
+- Review all fields/uploads/analytics.
+- Access admin overview endpoints.
+
+Admin-only endpoints use `require_admin` and return `403` for regular users.
+
+## Error Handling
+
+Expected access errors:
+
+- `401`: missing, invalid, expired, malformed, or inactive-user token.
+- `403`: authenticated user attempted to access another workspace or admin-only area.
+- `404`: hidden result/field lookup where revealing existence is not appropriate, such as another user's upload result.
+
+Authentication and permission errors intentionally avoid stack traces and sensitive backend details.
+
+## Frontend Session Flow
+
+The React frontend stores the bearer token in `localStorage` under `auth_token`.
+
+Client flow:
+
+1. Login or registration receives `access_token`.
+2. The token is stored locally.
+3. Protected routes call `/api/auth/me` to validate the session.
+4. API client sends `Authorization: Bearer <token>` on protected requests.
+5. Failed session refresh clears the local token and user state.
+6. Protected UI routes redirect unauthenticated users to `/login`.
+
+## MVP Testing Checklist
+
+- Call protected endpoints without a token and verify `401`.
+- Log in as user A and create a field/trap/upload.
+- Log in as user B and verify user A's field/trap/upload/result cannot be accessed.
+- Verify user B does not see user A data in analytics or environmental views.
+- Verify admin can access overview and cross-workspace monitoring.
+- Verify failed login/register attempts are throttled after repeated attempts.
+- Verify frontend clears a stale token after `/api/auth/me` fails.

--- a/docs/structured_flows/workflow_catalog.md
+++ b/docs/structured_flows/workflow_catalog.md
@@ -7,7 +7,8 @@ This document lists the major operational workflows in the insect identification
 - Scope: registration, login, token validation, role-based access.
 - Backend entry points: `app/api/auth.py`, `app/api/deps.py`.
 - Risks: invalid tokens, unauthorized field access.
-- Status: documented at high-level in traceability matrix.
+- Detailed doc: `auth_access_control_flow.md`.
+- Related issue: `#93`.
 
 ## WF-02 Field and Trap Management
 


### PR DESCRIPTION
What was covered for #93:

Protected map search with backend auth.
Centralized field/workspace ownership checks.
Reused workspace checks across map, upload/analysis, analytics, and environmental monitoring flows.
Added cross-workspace denial coverage for field and upload workflows.
Added frontend session tests for stored token usage, invalid-token clearing, login/register token flow, and authenticated map search calls.
Added MVP auth/access-control documentation.