### PR TITLE
fix(analytics): restore image open action in insights table (#144)

### DIFF
--- a/03_application/backend/app/api/analysis.py
+++ b/03_application/backend/app/api/analysis.py
@@ -2,11 +2,13 @@ import json
 from collections import defaultdict
 from datetime import date
 from html import escape
+import mimetypes
 from pathlib import Path
 import re
 import logging
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 from sqlalchemy import and_, extract, func
 from sqlalchemy.orm import Session
 import requests
@@ -271,6 +273,33 @@ def get_upload_prediction_result(
             for detection in detections
         ],
     )
+
+
+@router.get('/uploads/{upload_id}/image')
+def get_upload_image(
+    upload_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    upload = db.query(TrapUpload).filter(TrapUpload.id == upload_id).first()
+    if upload is None or (current_user.role != 'admin' and upload.user_id != current_user.id):
+        raise HTTPException(status_code=404, detail='Upload not found')
+
+    settings = get_settings()
+    upload_root = Path(settings.upload_dir).expanduser().resolve()
+    stored_path = Path(upload.image_path).expanduser()
+    resolved_path = (stored_path if stored_path.is_absolute() else (Path.cwd() / stored_path)).resolve()
+
+    try:
+        resolved_path.relative_to(upload_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail='Upload image is outside the configured storage root') from exc
+
+    if not resolved_path.is_file():
+        raise HTTPException(status_code=404, detail='Upload image file not found on disk')
+
+    media_type = mimetypes.guess_type(resolved_path.name)[0] or 'application/octet-stream'
+    return FileResponse(path=resolved_path, media_type=media_type, filename=resolved_path.name)
 
 
 @router.get('/model-stats')

--- a/03_application/frontend/src/api/client.ts
+++ b/03_application/frontend/src/api/client.ts
@@ -70,6 +70,31 @@ async function requestText(path: string, init: RequestInit = {}, token?: string)
   return response.text();
 }
 
+async function requestBlob(path: string, init: RequestInit = {}, token?: string): Promise<Blob> {
+  const headers = new Headers(init.headers || {});
+  headers.set('Accept', 'image/*, application/octet-stream');
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers,
+      referrerPolicy: 'same-origin',
+    });
+  } catch {
+    throw new Error(`Cannot reach API at ${API_BASE}. Ensure backend is running on port 8000.`);
+  }
+
+  if (!response.ok) {
+    throw new Error(await apiErrorMessage(response));
+  }
+
+  return response.blob();
+}
+
 export const apiClient = {
   get: <T>(path: string, token?: string) => request<T>(path, { method: 'GET' }, token),
   post: <T>(path: string, body: unknown, token?: string) =>
@@ -79,4 +104,5 @@ export const apiClient = {
   postForm: <T>(path: string, body: FormData, token?: string) =>
     request<T>(path, { method: 'POST', body }, token),
   getText: (path: string, token?: string) => requestText(path, { method: 'GET' }, token),
+  getBlob: (path: string, token?: string) => requestBlob(path, { method: 'GET' }, token),
 };

--- a/03_application/frontend/src/pages/DashboardPage.tsx
+++ b/03_application/frontend/src/pages/DashboardPage.tsx
@@ -406,6 +406,22 @@ export default function DashboardPage() {
     }
   };
 
+  const openInsightImage = async (uploadId: number) => {
+    if (!token) return;
+    setError('');
+    try {
+      const imageBlob = await apiClient.getBlob(`/api/analysis/uploads/${uploadId}/image`, token);
+      const href = URL.createObjectURL(imageBlob);
+      const opened = window.open(href, '_blank', 'noopener,noreferrer');
+      if (!opened) {
+        setError('Popup blocked while opening image. Allow popups and try again.');
+      }
+      setTimeout(() => URL.revokeObjectURL(href), 60_000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open image');
+    }
+  };
+
   const loadModelStats = async () => {
     if (!token) return;
     const payload = await apiClient.get<ModelStats>('/api/analysis/model-stats', token);
@@ -951,9 +967,14 @@ export default function DashboardPage() {
                         <td>{fmt(row.confidence_avg, 2)}</td>
                         <td>{row.detections.length}</td>
                         <td>
-                          <button type="button" className="link-btn table-action" onClick={() => void inspectInsightUpload(row.upload_id)}>
-                            Open
-                          </button>
+                          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                            <button type="button" className="link-btn table-action" onClick={() => void openInsightImage(row.upload_id)}>
+                              View Image
+                            </button>
+                            <button type="button" className="link-btn table-action" onClick={() => void inspectInsightUpload(row.upload_id)}>
+                              Details
+                            </button>
+                          </div>
                         </td>
                       </tr>
                     ))}

--- a/03_application/frontend/src/pages/__tests__/DashboardPage.test.tsx
+++ b/03_application/frontend/src/pages/__tests__/DashboardPage.test.tsx
@@ -5,6 +5,7 @@ const getMock = vi.fn();
 const postMock = vi.fn();
 const postFormMock = vi.fn();
 const getTextMock = vi.fn();
+const getBlobMock = vi.fn();
 const logoutMock = vi.fn();
 
 vi.mock('../../api/client', () => ({
@@ -13,6 +14,7 @@ vi.mock('../../api/client', () => ({
     post: (...args: unknown[]) => postMock(...args),
     postForm: (...args: unknown[]) => postFormMock(...args),
     getText: (...args: unknown[]) => getTextMock(...args),
+    getBlob: (...args: unknown[]) => getBlobMock(...args),
   },
 }));
 
@@ -203,11 +205,14 @@ describe('DashboardPage', () => {
     postMock.mockReset();
     postFormMock.mockReset();
     getTextMock.mockReset();
+    getBlobMock.mockReset();
     Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: vi.fn(() => 'blob:insights') });
     Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() });
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+    vi.spyOn(window, 'open').mockImplementation(() => ({ closed: false } as Window));
     setupGetMocks();
     getTextMock.mockResolvedValue('report,Insight dashboard export\n');
+    getBlobMock.mockResolvedValue(new Blob(['image-bytes'], { type: 'image/jpeg' }));
     postMock.mockResolvedValue({
       answer: 'ok',
       used_openai: false,
@@ -225,6 +230,17 @@ describe('DashboardPage', () => {
     await waitFor(() => expect(screen.getByText('Environmental Data (Field Weather + Derived Metrics)')).toBeInTheDocument());
     expect(screen.getAllByText(/Scope:/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Totals/)).toBeInTheDocument();
+  });
+
+  it('opens insight image from analytics table', async () => {
+    render(<DashboardPage />);
+    fireEvent.click(screen.getByRole('button', { name: /Monitoring Analytics/i }));
+    await waitFor(() => expect(screen.getByText('Environmental Data (Field Weather + Derived Metrics)')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Image' }));
+
+    await waitFor(() => expect(getBlobMock).toHaveBeenCalledWith('/api/analysis/uploads/1/image', 'token-1'));
+    expect(window.open).toHaveBeenCalledWith('blob:insights', '_blank', 'noopener,noreferrer');
   });
 
   it('handles upload trap selection and exploratory chat flow', async () => {
@@ -317,7 +333,7 @@ describe('DashboardPage', () => {
       expect(getMock).toHaveBeenCalledWith(expect.stringContaining('max_detections=10'), 'token-1');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
     await waitFor(() => expect(screen.getByText('Image Result #1')).toBeInTheDocument());
     expect(screen.getByText(/class=0, confidence=0.810/)).toBeInTheDocument();
 

--- a/03_application/tests/backend/test_ingestion_pipeline_workflow.py
+++ b/03_application/tests/backend/test_ingestion_pipeline_workflow.py
@@ -324,6 +324,71 @@ def test_get_upload_prediction_result_enforces_upload_ownership(
     assert exc.value.status_code == 404
 
 
+def test_get_upload_image_returns_file_response_for_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    db_session: Session,
+    ingestion_user_and_field: tuple[User, FieldMap],
+) -> None:
+    user, field = ingestion_user_and_field
+    upload_dir = tmp_path / "uploads"
+    image_dir = upload_dir / "field-ingestion" / "2026" / "05" / "02" / "FIELD_BATCH"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    image_path = image_dir / "open-image.jpg"
+    image_path.write_bytes(JPEG_BYTES)
+
+    upload = TrapUpload(
+        user_id=user.id,
+        field_id=field.id,
+        trap_id=None,
+        trap_code="FIELD_BATCH",
+        capture_date=date(2026, 5, 2),
+        image_path=str(image_path),
+        detection_count=0,
+        confidence_avg=0.0,
+    )
+    db_session.add(upload)
+    db_session.commit()
+
+    monkeypatch.setattr(analysis_api, "get_settings", lambda: SimpleNamespace(upload_dir=str(upload_dir)))
+    response = analysis_api.get_upload_image(upload.id, db=db_session, current_user=user)
+
+    assert response.status_code == 200
+    assert Path(response.path) == image_path
+    assert response.media_type == "image/jpeg"
+
+
+def test_get_upload_image_rejects_paths_outside_configured_upload_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    db_session: Session,
+    ingestion_user_and_field: tuple[User, FieldMap],
+) -> None:
+    user, field = ingestion_user_and_field
+    upload_dir = tmp_path / "uploads"
+    outside_path = tmp_path / "outside.jpg"
+    outside_path.write_bytes(JPEG_BYTES)
+
+    upload = TrapUpload(
+        user_id=user.id,
+        field_id=field.id,
+        trap_id=None,
+        trap_code="FIELD_BATCH",
+        capture_date=date(2026, 5, 2),
+        image_path=str(outside_path),
+        detection_count=0,
+        confidence_avg=0.0,
+    )
+    db_session.add(upload)
+    db_session.commit()
+
+    monkeypatch.setattr(analysis_api, "get_settings", lambda: SimpleNamespace(upload_dir=str(upload_dir)))
+    with pytest.raises(HTTPException) as exc:
+        analysis_api.get_upload_image(upload.id, db=db_session, current_user=user)
+
+    assert exc.value.status_code == 403
+
+
 def test_upload_range_rejects_invalid_batch_before_storage(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Description

Summary
Fixes bug #144 where clicking View Image in Analytics Insights did nothing.

What changed
Added secured backend endpoint to serve upload images:
GET /api/analysis/uploads/{upload_id}/image
Enforced access + path safety:
respects upload ownership/admin access
blocks paths outside configured upload root
Updated frontend analytics table actions:
View Image now opens image in a new tab
Details keeps existing prediction-detail panel behavior
Added/updated tests:
backend tests for image retrieval + path protection
frontend tests for View Image + Details actions
Validation
Backend targeted tests passed:
test_ingestion_pipeline_workflow.py (get_upload_image / get_upload_prediction_result)
Frontend tests passed:
DashboardPage.test.tsx (11/11)
Bug
Closes #144